### PR TITLE
Handled graceful shutdown of HTTP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,8 @@ require (
 	github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 // indirect
 	github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,10 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver v1.17.0 h1:Hp4q2MCjvY19ViwimTs00wHi7G4yzxh4/2+nTx8r40k=
 go.mongodb.org/mongo-driver v1.17.0/go.mod h1:wwWm/+BuOddhcq3n68LKRmgk2wXzmF6s0SFOa0GINL4=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=

--- a/main.go
+++ b/main.go
@@ -347,16 +347,29 @@ func CORSMiddleware() gin.HandlerFunc {
 	}
 }
 
-func GracefulShutdown() {
-	stopper := make(chan os.Signal, 1)
-	// listens for interrupt and SIGTERM signal
-	signal.Notify(stopper, os.Interrupt, os.Kill, syscall.SIGKILL, syscall.SIGTERM)
-	go func() {
-		select {
-		case <-stopper:
-			os.Exit(0)
-		}
-	}()
+// GracefulShutdown handles graceful shutdown of the server and ticker
+func GracefulShutdown(server *http.Server, ticker *time.Ticker) {
+    stopper := make(chan os.Signal, 1)
+    // Listen for interrupt and SIGTERM signals
+    signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
+
+    go func() {
+        <-stopper
+        fmt.Println("Shutting down gracefully...")
+
+        // Stop the ticker
+        ticker.Stop()
+
+        // Create a context with a timeout for shutdown
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
+        // Shut down the server
+        if err := server.Shutdown(ctx); err != nil {
+            log.Fatalf("Server shutdown failed: %+v", err)
+        }
+        fmt.Println("Server exited gracefully")
+    }()
 }
 
 func checkInstrumentName(input string) bool {
@@ -743,17 +756,26 @@ func main() {
 		v1.POST("/uploadXlsx", parseXlsxFile)
 		v1.GET("/keepServerRunning", runningServer)
 	}
-	GracefulShutdown()
 
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "4000"
 	}
 
-	err := router.Run(":" + port)
-	if err != nil {
-		log.Fatalf("Error starting server: %v", err)
-	}
+	// Create a server instance using gin engine as handler
+    server := &http.Server{
+        Addr:    ":" + port,
+        Handler: router,
+    }
+
+    // Call GracefulShutdown with the server and ticker
+    GracefulShutdown(server, ticker)
+
+    // Start the server
+    if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+        log.Fatalf("Error starting server: %v", err)
+    }
+
 }
 
 func fetchCompanyData(url string) (map[string]interface{}, error) {


### PR DESCRIPTION
Fixes #14 

This PR introduces a GracefulShutdown function for the HTTP server, allowing it to handle shutdown signals (like interrupt or SIGTERM) gracefully. This enhancement ensures that the server can terminate without abruptly cutting off ongoing requests, providing a better user experience and preventing potential data loss.

